### PR TITLE
Update for React Native 0.25

### DIFF
--- a/TimeAgo.js
+++ b/TimeAgo.js
@@ -1,10 +1,10 @@
-var React = require('react-native');
-var {
-  PropTypes,
-  Text
-} = React;
+var React = require('react')
+var ReactNative = require('react-native');
 var moment = require('moment');
 var TimerMixin = require('react-timer-mixin');
+
+var { PropTypes } = React;
+var { Text } = ReactNative;
 
 var TimeAgo = React.createClass({
   mixins: [TimerMixin],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-timeago",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Auto-updating timeago component for React Native",
   "main": "TimeAgo.js",
   "scripts": {
@@ -15,7 +15,8 @@
   "peerDependencies": {
     "moment": "2.x.x",
     "react-timer-mixin": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react": ">=0.14.0"
   },
   "author": "Tyler Hughes <iampbt@gmail.com>",
   "repository": {


### PR DESCRIPTION
Requiring React API from `react-native` is now deprecated in 0.25.
