### PR TITLE
Updated TimeAgo to ES6/flow types, removed the timer-mixin

### DIFF
--- a/TimeAgo.js
+++ b/TimeAgo.js
@@ -1,51 +1,48 @@
-var React = require('react')
-var ReactNative = require('react-native');
-var moment = require('moment');
-var TimerMixin = require('react-timer-mixin');
+// @flow
+import React, { Component } from "react";
+import { View, Text } from "react-native";
+import moment from "moment";
 
-var { PropTypes } = React;
-var { Text } = ReactNative;
+export default class TimeAgo extends Component {
+  props: {
+    time: string,
+    interval?: number,
+    hideAgo?: boolean
+  };
+  state: { timer: null | number } = { timer: null };
 
-var TimeAgo = React.createClass({
-  mixins: [TimerMixin],
-  propTypes: {
-    time: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number,
-      React.PropTypes.array,
-      React.PropTypes.instanceOf(Date)
-    ]).isRequired,
-    interval: PropTypes.number,
-    hideAgo: PropTypes.bool
-  },
-
-  getDefaultProps() {
-    return {
-      hideAgo: false,
-      interval: 60000
-    }
-  },
+  static defaultProps = {
+    hideAgo: false,
+    interval: 60000
+  };
 
   componentDidMount() {
-    var {interval} = this.props;
-    this.setInterval(this.update, interval);
-  },
+    this.createTimer();
+  }
+
+  createTimer = () => {
+    this.setState({
+      timer: setTimeout(() => {
+        this.update();
+      }, this.props.interval)
+    });
+  };
 
   componentWillUnmount() {
-    this.clearInterval(this.update);
-  },
+    clearTimeout(this.state.timer);
+  }
 
-  // We're using this method because of a weird bug
-  // where autobinding doesn't seem to work w/ straight this.forceUpdate
-  update() {
+  update = () => {
     this.forceUpdate();
-  },
+    this.createTimer();
+  };
 
   render() {
+    const { time, hideAgo } = this.props;
     return (
-      <Text {...this.props}>{moment(this.props.time).fromNow(this.props.hideAgo)}</Text>
+      <Text {...this.props}>
+        {moment(time).fromNow(hideAgo)}
+      </Text>
     );
   }
-});
-
-module.exports = TimeAgo;
+}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   ],
   "peerDependencies": {
     "moment": "2.x.x",
-    "react-timer-mixin": "*",
     "react-native": "*",
     "react": ">=0.14.0"
   },


### PR DESCRIPTION
This updates to ES6, removes the deprecated PropTypes in favour of Flow.
Also removes the dependency on the TimerMixin, which is not ready for ES6 style classes