### PR TITLE
update prop-types for RN 16, update to es6

### DIFF
--- a/TimeAgo.js
+++ b/TimeAgo.js
@@ -1,51 +1,52 @@
-var React = require('react')
-var ReactNative = require('react-native');
-var moment = require('moment');
-var TimerMixin = require('react-timer-mixin');
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Text } from 'react-native';
+import moment from 'moment';
+import TimerMixin from 'react-timer-mixin';
 
-var { PropTypes } = React;
-var { Text } = ReactNative;
-
-var TimeAgo = React.createClass({
-  mixins: [TimerMixin],
-  propTypes: {
-    time: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number,
-      React.PropTypes.array,
-      React.PropTypes.instanceOf(Date)
+class TimeAgo extends Component {
+  static propTypes = {
+    time: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.array,
+      PropTypes.instanceOf(Date)
     ]).isRequired,
     interval: PropTypes.number,
     hideAgo: PropTypes.bool
-  },
+  };
 
   getDefaultProps() {
     return {
       hideAgo: false,
       interval: 60000
-    }
-  },
+    };
+  }
 
   componentDidMount() {
-    var {interval} = this.props;
+    const { interval } = this.props;
     this.setInterval(this.update, interval);
-  },
+  }
 
   componentWillUnmount() {
     this.clearInterval(this.update);
-  },
+  }
 
   // We're using this method because of a weird bug
   // where autobinding doesn't seem to work w/ straight this.forceUpdate
   update() {
     this.forceUpdate();
-  },
+  }
 
   render() {
     return (
-      <Text {...this.props}>{moment(this.props.time).fromNow(this.props.hideAgo)}</Text>
+      <Text {...this.props}>
+        {moment(this.props.time).fromNow(this.props.hideAgo)}
+      </Text>
     );
   }
-});
+}
 
-module.exports = TimeAgo;
+Object.assign(TimeAgo.prototype, TimerMixin);
+
+export default TimeAgo;


### PR DESCRIPTION
`React.createClass` and `React.PropTypes` are now deprecated. This change updates this library to use `React.Component` with **ES6** and the standalone **prop-types** library.