### PR TITLE
Clear Timeout to avoid unmounted update warning

### DIFF
--- a/TimeAgo.js
+++ b/TimeAgo.js
@@ -34,6 +34,7 @@ export default class TimeAgo extends Component {
 
   update = () => {
     this.forceUpdate();
+    clearTimeout(this.state.timer);
     this.createTimer();
   };
 

--- a/TimeAgo.js
+++ b/TimeAgo.js
@@ -22,20 +22,18 @@ export default class TimeAgo extends Component {
 
   createTimer = () => {
     this.setState({
-      timer: setTimeout(() => {
+      timer: setInterval(() => {
         this.update();
       }, this.props.interval)
     });
   };
 
   componentWillUnmount() {
-    clearTimeout(this.state.timer);
+    clearInterval(this.state.timer);
   }
 
   update = () => {
     this.forceUpdate();
-    clearTimeout(this.state.timer);
-    this.createTimer();
   };
 
   render() {


### PR DESCRIPTION
Clear time out before update to avoid `Can't call setState (or forceUpdate) on an unmounted component` warning